### PR TITLE
Vertx version typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Incubator for virtual threads based prototypes.
 
 ## Prerequisites
 
-- [Vert.x 4.3.4](https://vertx.io/docs/4.3.4)
+- [Vert.x 4.3.3](https://vertx.io/docs/4.3.3)
 - Java 19 using preview feature
   - [OpenJDK 19 EA](https://jdk.java.net/19/)
   - [Maven](https://stackoverflow.com/questions/52232681/compile-and-execute-a-jdk-preview-feature-with-maven)


### PR DESCRIPTION
I think 4.3.3 is the version used in the pom

```
  <properties>
    <vertx.version>4.3.3</vertx.version>
  </properties>

```