### PR TITLE
Completed futures should not park

### DIFF
--- a/vertx-async-await-incubator/src/main/java/io/vertx/await/Async.java
+++ b/vertx-async-await-incubator/src/main/java/io/vertx/await/Async.java
@@ -1,20 +1,16 @@
 package io.vertx.await;
 
 import io.netty.channel.EventLoop;
+import io.vertx.await.impl.DefaultScheduler;
 import io.vertx.await.impl.EventLoopScheduler;
 import io.vertx.await.impl.Scheduler;
 import io.vertx.await.impl.VirtualThreadContext;
-import io.vertx.await.impl.DefaultScheduler;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.NoStackTraceThrowable;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.Lock;
 
 public class Async {

--- a/vertx-async-await-incubator/src/main/java/io/vertx/await/Async.java
+++ b/vertx-async-await-incubator/src/main/java/io/vertx/await/Async.java
@@ -8,8 +8,12 @@ import io.vertx.await.impl.DefaultScheduler;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceThrowable;
 
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.Lock;
 
@@ -58,7 +62,7 @@ public class Async {
     ctx.lock(lock);
   }
 
-  public static <T> T await(CompletionStage<T> future) {
+  public static <T> T await(CompletableFuture<T> future) {
     VirtualThreadContext ctx = virtualThreadContext();
     return ctx.await(future);
   }

--- a/vertx-async-await-incubator/src/main/java/io/vertx/await/impl/VirtualThreadContext.java
+++ b/vertx-async-await-incubator/src/main/java/io/vertx/await/impl/VirtualThreadContext.java
@@ -158,7 +158,14 @@ public class VirtualThreadContext extends ContextBase {
     }
   }
 
-  public <T> T await(CompletionStage<T> fut) {
+  public <T> T await(CompletableFuture<T> fut) {
+    if (fut.state() == java.util.concurrent.Future.State.SUCCESS) {
+      return fut.resultNow();
+    }
+    if (fut.state() == java.util.concurrent.Future.State.FAILED) {
+      throwAsUnchecked(fut.exceptionNow());
+      return null;
+    }
     inThread.remove();
     Consumer<Runnable> cont = scheduler.unschedule();
     CompletableFuture<T> latch = new CompletableFuture<>();


### PR DESCRIPTION
Motivation:

Already completed futures should not park the thread. Currently, they do. This can improve performance.

This also resolves an ordering issue in the default event loop context.
